### PR TITLE
Emit telemetry after running main

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ async function main() {
     await deployment.create(idToken)
     await deployment.check()
   } catch (error) {
-    core.info(JSON.stringify(error))
+
     core.setFailed(error)
   }
 }
@@ -53,4 +53,4 @@ process.on('SIGINT', cancelHandler)
 process.on('SIGTERM', cancelHandler)
 
 // Main
-main()
+main().then(() => require('./pre').emitTelemetry())


### PR DESCRIPTION
This is a bit of hack to run the same thing we do in the `pre.js` step after running main.